### PR TITLE
fixed from PVS-Studio

### DIFF
--- a/imgui/imgui_demo.cpp
+++ b/imgui/imgui_demo.cpp
@@ -2051,7 +2051,7 @@ struct ExampleAppConsole
     // Portable helpers
     static int   Stricmp(const char* str1, const char* str2)         { int d; while ((d = toupper(*str2) - toupper(*str1)) == 0 && *str1) { str1++; str2++; } return d; }
     static int   Strnicmp(const char* str1, const char* str2, int n) { int d = 0; while (n > 0 && (d = toupper(*str2) - toupper(*str1)) == 0 && *str1) { str1++; str2++; n--; } return d; }
-    static char* Strdup(const char *str)                             { size_t len = strlen(str) + 1; void* buff = malloc(len); return (char*)memcpy(buff, (const void*)str, len); }
+	static char* Strdup(const char *str) { size_t len = strlen(str) + 1; void* buff = malloc(len); if (buff) return (char*)memcpy(buff, (const void*)str, len); else return(NULL); }
 
     void    ClearLog()
     {


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warnings:

[V575](https://www.viva64.com/en/w/v575/) The potential null pointer is passed into 'memcpy' function. Inspect the first argument. imgui_demo.cpp 2054